### PR TITLE
Update part-1.md

### DIFF
--- a/en/tutorials/book-store/part-1.md
+++ b/en/tutorials/book-store/part-1.md
@@ -450,7 +450,17 @@ ABP can [**automagically**](https://docs.abp.io/en/abp/latest/API/Auto-API-Contr
 
 ### Swagger UI
 
-The startup template is configured to run the [Swagger UI](https://swagger.io/tools/swagger-ui/) using the [Swashbuckle.AspNetCore](https://github.com/domaindrivendev/Swashbuckle.AspNetCore) library. Run the application ({{if UI=="MVC"}}`Acme.BookStore.Web`{{else}}`Acme.BookStore.HttpApi.Host`{{end}}) by pressing `CTRL+F5` and navigate to `https://localhost:<port>/swagger/` on your browser. Replace `<port>` with your own port number.
+The startup template is configured to run the [Swagger UI](https://swagger.io/tools/swagger-ui/) using the [Swashbuckle.AspNetCore](https://github.com/domaindrivendev/Swashbuckle.AspNetCore) library. 
+
+Before proceeding with building and running the project, verify the database connection string points to your database. It's in the Web project's json file here: Acme.Bookstore.Web\appsettings.json
+
+Also, comment out the Automapper for Appuser. Otherwise the project won't build. This automapper entry is unnecessary as of v4.0.0. The file is located here: Acme.BookStore.Application\BookStoreApplicationAutoMapperProfile.cs:
+````csharp
+//CreateMap<AppUser, AppUserDto>().Ignore(x => x.ExtraProperties);
+````
+
+
+Run the application ({{if UI=="MVC"}}`Acme.BookStore.Web`{{else}}`Acme.BookStore.HttpApi.Host`{{end}}) by pressing `CTRL+F5` and navigate to `https://localhost:<port>/swagger/` on your browser. Replace `<port>` with your own port number. 
 
 You will see some built-in service endpoints as well as the `Book` service and its REST-style endpoints:
 


### PR DESCRIPTION
ABP.IO v4.1.0 MVC / EF Core Bookstore Tutorial

In the Bookstore tutorial, part 1, https://docs.abp.io/en/commercial/latest/tutorials/book-store/part-1?UI=MVC&DB=EF there are missing steps that must be done before building and then accessing the swagger UI.

1. Comment out the Automapper for Appuser. Otherwise the project won't build.
File: Acme.BookStore.Application\BookStoreApplicationAutoMapperProfile.cs
Change: //CreateMap<AppUser, AppUserDto>().Ignore(x => x.ExtraProperties);

2. Add connection string to your Acme.Bookstore.Web project's appsettings.json file. Otherwise you'll get an SQL error when running Swagger UI calls.
File: Acme.Bookstore.Web\appsettings.json
Change: Add database connection string to Acme.Bookstore.Web\appsettings.json (copy from Acme.Bookstore.DbMigrator\appsettings.json