### PR TITLE
Use Visible instead of RequiredPolicy for Blazor

### DIFF
--- a/en/tutorials/book-store/part-5.md
+++ b/en/tutorials/book-store/part-5.md
@@ -530,7 +530,7 @@ Wrap the *New Book* button by an `if` block as shown below:
 
 #### Hide the Edit/Delete Actions
 
-`EntityAction` component defines `RequiredPolicy` attribute (parameter) to conditionally show the action based on the user permissions.
+`EntityAction` component defines `Visible` attribute (parameter) to conditionally show the action.
 
 Update the `EntityActions` section as shown below:
 
@@ -538,11 +538,11 @@ Update the `EntityActions` section as shown below:
 <EntityActions TItem="BookDto" EntityActionsColumn="@EntityActionsColumn">
     <EntityAction TItem="BookDto"
                   Text="@L["Edit"]"
-                  RequiredPolicy="@UpdatePolicyName"
+                  Visible=HasUpdatePermission
                   Clicked="() => OpenEditModalAsync(context)" />
     <EntityAction TItem="BookDto"
                   Text="@L["Delete"]"
-                  RequiredPolicy="@DeletePolicyName"
+                  Visible=HasDeletePermission
                   Clicked="() => DeleteEntityAsync(context)"
                   ConfirmationMessage="()=>GetDeleteConfirmationMessage(context)" />
 </EntityActions>


### PR DESCRIPTION
As in [this PR](https://github.com/abpframework/abp/pull/8225) I haven't updated the image because it looks like it is up to date already.

https://github.com/abpio/abp-commercial-docs/blob/dev/en/tutorials/book-store/images/blazor-edit-book-action-2.png