### PR TITLE
Update LeptonX MVC Documentation

### DIFF
--- a/en/themes/lepton-x/commercial/mvc.md
+++ b/en/themes/lepton-x/commercial/mvc.md
@@ -3,10 +3,12 @@ LeptonX theme is implemented and ready to use with ABP Commercial. No custom imp
 
 ## Installation
 
-- Install package to your **Web** project with CLI.
+- Install package to your **Web** project with the following CLI command:
+
 ```bash
-abp add-package Volo.Abp.AspNetCore.Mvc.UI.Theme.LeptonX --prerelease
+dotnet add package Volo.Abp.AspNetCore.Mvc.UI.Theme.LeptonX --prerelease
 ```
+
 - Remove `Volo.Abp.AspNetCore.Mvc.UI.Theme.Lepton` and `Volo.Abp.LeptonTheme.Management.Web` references from the project since it's not necessary after switching to LeptonX.
 
 - Make sure the old theme is removed and LeptonX is added in your Module class.


### PR DESCRIPTION
It seems we should not use `--prerelease` (with `abp add-package` command) because it tries to find the preview version of ABP (**v5.3.0-rc.1**)

![img](https://user-images.githubusercontent.com/43685404/169658196-75e122fc-bb97-4409-9f09-1b84216cd85d.png)
