### PR TITLE
Resolving Toolbar and BookStoreResource error for BlazorServer-EF

### DIFF
--- a/en/tutorials/book-store/part-2.md
+++ b/en/tutorials/book-store/part-2.md
@@ -656,12 +656,12 @@ Then open the `Books.razor` and replace the content as the following:
 @using Acme.BookStore.Localization
 @using Volo.Abp.AspNetCore.Components.Web.Theming.Layout
 @using Microsoft.Extensions.Localization
-@inject IStringLocalizer<BookStoreResource> L
+
 @inherits AbpCrudPageBase<IBookAppService, BookDto, Guid, PagedAndSortedResultRequestDto, CreateUpdateBookDto>
 
 <CascadingValue Value="this">
     @* ************************* PAGE HEADER ************************* *@
-    <PageHeader Title="@L["Books"]" BreadcrumbItems="@BreadcrumbItems" Toolbar="@Toolbar">
+    <PageHeader Title="@L["Books"]" BreadcrumbItems="@BreadcrumbItems">
     </PageHeader>
 
     <Card>


### PR DESCRIPTION
`Toolbar="@Toolbar"` gives an error for BlazorServer-EF. `@L["Books"]` also gives an error.

1. I was unable to see the use of Toolbar anywhere else in the code - so I guessed that that might need to be removed.
2. `@inject IStringLocalizer<BookStoreResource> L` is not required.

I am unsure if my proposed changes are the correct fix, but they finally allowed my application to run. (I have tried completing the BookStore tutorial several times in the past but gave up when I encountered errors.)

I hope that the errors faced when completing [https://docs.abp.io/en/commercial/latest/tutorials/book-store/part-2?UI=BlazorServer&DB=EF](url) is resolved.