### PR TITLE
Fix incorrect namespace for BlazorServer-EF

### DIFF
--- a/en/tutorials/book-store/part-2.md
+++ b/en/tutorials/book-store/part-2.md
@@ -639,7 +639,7 @@ Create `Books.razor.cs` next to `Books.razor` file:
 using Volo.Abp.AspNetCore.Components.Web.Theming.PageToolbars;
 {{if UI == "MAUIBlazor"}}
 namespace Acme.BookStore.MauiBlazor.Pages; {{else}}
-namespace Acme.BookStore.Blazor; {{end}}
+namespace Acme.BookStore.Blazor.Pages; {{end}}
 
 public partial class Books
 {


### PR DESCRIPTION
Adding `.Pages` at the end of `namespace Acme.BookStore.Blazor` resolves the error that is generated for `Toolbar="@Toolbar"` on `Books.razor`. This is for BlazorServer template.

Error without `.Pages`:
> CS0103: The name 'Toolbar' does not exist in the current context.

Fixing this helps the learner to complete Parts 2 and 3... of the tutorial.