### PR TITLE
Update Getting-Started-Running-Solution Documentation for Blazor WASM & Server

### DIFF
--- a/en/getting-started-running-solution.md
+++ b/en/getting-started-running-solution.md
@@ -129,6 +129,29 @@ abp bundle
 
 > Note: When you create an ABP solution, the client-side packages are being restored by ABP CLI and Suite. But if you fetch the source-code that's commited by another team member, your `libs` folder will be empty. Before starting the application, run `abp install-libs` command in your Web directory to restore the client-side libraries. This will populate the `libs` folder.
 
+{{ if UI == "BlazorServer" }}
+
+> **Important:**  The `.AuthServer` application serves as the **Authentication Server** for the `.Blazor` application. It is essential to have the `.AuthServer` application running in the background to ensure the proper functioning of the `.Blazor` application.
+
+To do this, open terminal in `.AuthServer` project folder and run the following command.
+
+````bash
+dotnet run
+````
+
+Once the `.AuthServer`application has started, it is time to run `.HttpApi.Host` application.
+
+> **Important:** Prior to launching the `.Blazor` project, it is essential to execute the `.HttpApi.Host` application as well.
+
+To do this, open terminal in `.HttpApi.Host` project folder and run the following command.
+
+````bash
+dotnet run
+````
+Once the `.AuthServer` and `.HttpApi.Host` applications has started, you can proceed to run the `.Blazor` project.
+
+{{ end # UI }}
+
 {{ if Tiered == "Yes" }}
 
 > Tiered solutions use Redis as the distributed cache. Ensure that it is installed and running in your local computer. If you are using a remote Redis Server, set the configuration in the `appsettings.json` files of the projects below.
@@ -200,6 +223,16 @@ You can see the application APIs and test them here. Get [more info](https://swa
 {{ if UI == "Blazor" }}
 
 ### Running the Blazor Application (Client Side)
+
+> **Important:**  The `.HttpApi.Host` application serves as the **Authentication Server** for the `.Blazor` application. It is essential to have the `.HttpApi.Host` application running in the background to ensure the proper functioning of the `.Blazor` application.
+
+To do this, you can open terminal in `.HttpApi.Host` project folder and run the following command.
+
+````bash
+dotnet run
+````
+
+Once the `.HttpApi.Host` application has started, you can proceed to run the `.Blazor` application.
 
 Ensure that the `.Blazor` project is the startup project and run the application.
 


### PR DESCRIPTION
comment ref https://github.com/volosoft/vs-internal/issues/3580#issuecomment-1895188924

Readers informed about AuthServer that they need to run before running .blazor application.

**For Blazor WASM**
![wasm](https://github.com/abpframework/abp/assets/50696649/b12e7519-3671-41e0-a81a-66bec66d3773)

**For Blazor Server**
![server](https://github.com/abpframework/abp/assets/50696649/6cb38ffa-f8ff-454a-931c-738e0b553415)
